### PR TITLE
Allow optionally specifying a name for retro attendees.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,4 @@ Contributors
 
 * [Matthew Patterson](https://github.com/matthewpatterson)
 * [Kevin Boschert](https://github.com/kcboschert)
+* [Drew Olson](https://github.com/drewolson)

--- a/src/client/author.js
+++ b/src/client/author.js
@@ -1,0 +1,37 @@
+'use strict';
+
+var Author = function(client) {
+  var self = this;
+  var $author;
+
+  $(function() {
+    $author = $('#author');
+  });
+
+  this.on = function() {
+    $author.show();
+    $author.delegate(':submit', 'click', self.submit);
+  };
+
+  this.off = function() {
+    $author.hide();
+  };
+
+  this.submit = function() {
+    var value = $('#card_author').val();
+
+    if (value === '') {
+      value = 'Anonymous';
+    }
+
+    localStorage.setItem('acclamation.author.name', value);
+    localStorage.setItem('acclamation.author.lastSessionId', client.sessionId);
+    client.initSession();
+  };
+
+  this.hasProvided = function() {
+    return localStorage.getItem('acclamation.author.lastSessionId') === client.sessionId;
+  };
+};
+
+module.exports = Author;

--- a/src/client/cardForm.js
+++ b/src/client/cardForm.js
@@ -39,6 +39,7 @@ var CardForm = function(client) {
     $textarea
       .slideDown('fast')
       .focus();
+
     $(e.currentTarget).addClass('selected');
     e.preventDefault();
   };
@@ -58,7 +59,8 @@ var CardForm = function(client) {
   this.persistCard = function(e) {
     var card = {
       topic: $cardForm.find('#cardtopics button.selected').val(),
-      title: $cardForm.find('textarea').val().trim()
+      title: $cardForm.find('textarea').val().trim(),
+      author: localStorage.getItem('acclamation.author.name')
     };
 
     if (card.topic === '' || card.title === '') {

--- a/src/client/cardWall.js
+++ b/src/client/cardWall.js
@@ -87,7 +87,7 @@ var CardWall = function(client) {
       '<i class="fa fa-2x ',
       iconMap[card.topic],
       '"></i>',
-      window.emojiParser(card.title, '/images/emoji'),
+      window.emojiParser(card.title, '/images/emoji') + ' - ' + window.emojiParser(card.author, '/images/emoji'),
       '<span class="vote-badge">', client.voting.signedVotesForCard(card.id), '</span>',
     ].join('');
   };

--- a/src/client/client.js
+++ b/src/client/client.js
@@ -2,6 +2,7 @@
 'use strict';
 
 var AddCard = require('./addCard');
+var Author = require('./author');
 var CardForm = require('./cardForm');
 var CardWall = require('./cardWall');
 var SessionManager = require('./sessionManager');
@@ -13,6 +14,7 @@ var Client = function() {
 
   this.socket = io.connect();
   this.temperature = new Temperature(this);
+  this.author = new Author(this);
   this.cardWall = new CardWall(this);
   this.addCard = new AddCard(this);
   this.cardForm = new CardForm(this);
@@ -24,6 +26,10 @@ var Client = function() {
     var next = self.showTemperature;
 
     if (self.temperature.hasVoted()) {
+      next = self.showAuthor;
+    }
+
+    if (self.author.hasProvided()) {
       next = self.initSession;
     }
 
@@ -38,6 +44,17 @@ var Client = function() {
   this.showTemperature = function() {
     $('#loader').hide();
     self.temperature.on();
+    self.author.off();
+    self.addCard.off();
+    self.cardWall.off();
+    self.cardForm.off();
+    self.voting.off();
+  };
+
+  this.showAuthor = function() {
+    $('#loader').hide();
+    self.temperature.off();
+    self.author.on();
     self.addCard.off();
     self.cardWall.off();
     self.cardForm.off();
@@ -51,6 +68,7 @@ var Client = function() {
   this.showCardWall = function() {
     $('#loader').hide();
     self.temperature.off();
+    self.author.off();
     self.cardWall.on();
 
     if (self.sessionManager.allowVoting && !self.sessionManager.allowNewCards) {

--- a/src/client/temperature.js
+++ b/src/client/temperature.js
@@ -26,7 +26,7 @@ var Temperature = function(client) {
 
   this.done = function() {
     self.recordVote();
-    client.initSession();
+    client.showAuthor();
   };
 
   this.error = function(err) {

--- a/src/models/card.js
+++ b/src/models/card.js
@@ -15,6 +15,7 @@ module.exports = function(options) {
   this.title = options.title;
   this.parent = options.parent;
   this.votes = 0;
+  this.author = options.author;
 
   this.load = function(id, done) {
     redis.hget('cards', id, function(err, res) {
@@ -71,6 +72,7 @@ module.exports = function(options) {
       type: this.type,
       topic: this.topic,
       title: this.title,
+      author: this.author,
       parent: this.parent,
       votes: this.votes
     };

--- a/src/moderator/cardWall.js
+++ b/src/moderator/cardWall.js
@@ -106,7 +106,7 @@ var CardWall = function(moderator) {
   };
 
   this.htmlForCard = function(card) {
-    return '<div class="vote-count' + (self.voting ? '' : ' hidden') + '">' + card.votes + '</div>' + window.emojiParser(card.title, '/images/emoji');
+    return '<div class="vote-count' + (self.voting ? '' : ' hidden') + '">' + card.votes + '</div>' + window.emojiParser(card.title, '/images/emoji') + ' - ' + window.emojiParser(card.author, '/images/emoji');
   };
 
   this.setVoting = function(allowVoting) {

--- a/src/views/client.ejs
+++ b/src/views/client.ejs
@@ -42,6 +42,16 @@
         </div>
       </div>
     </section>
+    <section id="author" style="display: none;">
+      <h1>What's your name?</h1>
+      <p>
+        Optionally provide your name.
+      </p>
+      <div id="author_form">
+        <input type="text" id="card_author" placeholder="And you are?"></input>
+        <input type="submit"></input>
+      </div>
+    </section>
     <section id="addcard" class="hidden">
       <button id="add_card_btn" class="pure-button pure-button-primary">+ New Card</button>
     </section>


### PR DESCRIPTION
This PR adds another step in the "participant" flow after the temperature check. It asks the user to optionally specify a name ('Anonymous' will be used if none is provided). This name will be associated with all cards added but not with temperature nor voting.
